### PR TITLE
resolves #3 process hyperlinked images

### DIFF
--- a/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
+++ b/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
@@ -118,7 +118,18 @@ public class ToAsciiDocSerializer implements Visitor {
 
     public void visit(ExpLinkNode node) {
         String text = printChildrenToString(node);
-        printLink(linkRenderer.render(node, text));
+        LinkRenderer.Rendering link = linkRenderer.render(node, text);
+        if (text.startsWith("image:")) {
+            if (text.endsWith("[]")) {
+                printer.print(text.substring(0, text.length() - 1) + "link=" + link.href + "]");
+            }
+            else {
+                printer.print(text.substring(0, text.length() - 1) + ",link=" + link.href + "]");
+            }
+        }
+        else {
+            printLink(link);
+        }
     }
 
     public void visit(HeaderNode node) {

--- a/src/test/resources/com/laamella/markdown_to_asciidoc/links.feature
+++ b/src/test/resources/com/laamella/markdown_to_asciidoc/links.feature
@@ -69,3 +69,26 @@ Feature: Links
 
     image:images/icons/home.png?width=100[Alt text]
     """
+
+  Scenario: Render a hyperlinked inline image with alt text
+    Given the Markdown source
+    """
+    [![Build Status](https://travis-ci.org/asciidoctor/asciidoctor.png)](https://travis-ci.org/asciidoctor/asciidoctor)
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    image:https://travis-ci.org/asciidoctor/asciidoctor.png[Build Status,link=https://travis-ci.org/asciidoctor/asciidoctor]
+    """
+
+  #failing
+  #Scenario: Render a hyperlinked inline image with no alt text
+  #  Given the Markdown source
+  #  """
+  #  [![](https://travis-ci.org/asciidoctor/asciidoctor.png)](https://travis-ci.org/asciidoctor/asciidoctor)
+  #  """
+  #  When it is converted to AsciiDoc
+  #  Then the result should match the AsciiDoc source
+  #  """
+  #  image:https://travis-ci.org/asciidoctor/asciidoctor.png[link=https://travis-ci.org/asciidoctor/asciidoctor]
+  #  """


### PR DESCRIPTION
This is a super hacky way to solve this problem (I'm not yet comfortable working with the Pegdown API). Hopefully it's enough to get you an idea of what we're trying to accomplish...esp the test.

Currently, this hack doesn't work if the image has no alt text in Markdown. For some reason, that gets parsed differently.
