### PR TITLE
fix lists with paragraph content

### DIFF
--- a/src/main/java/com/laamella/markdown_to_asciidoc/Converter.java
+++ b/src/main/java/com/laamella/markdown_to_asciidoc/Converter.java
@@ -42,6 +42,6 @@ public class Converter {
         PegDownProcessor processor = new PegDownProcessor(Extensions.ALL);
         char[] markDown = markdown.toCharArray();
         RootNode rootNode = processor.parseMarkdown(markDown);
-        return new ToAsciiDocSerializer().toAsciiDoc(rootNode);
+        return new ToAsciiDocSerializer(rootNode).toAsciiDoc();
     }
 }

--- a/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
+++ b/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
@@ -29,16 +29,23 @@ public class ToAsciiDocSerializer implements Visitor {
     // Experimental feature.
     protected boolean autoDetectLanguageType;
     protected Linguist linguist = new Linguist();
+    
+    protected RootNode rootNode;
 
-    public ToAsciiDocSerializer() {
+    public ToAsciiDocSerializer(RootNode rootNode) {
+    	this.printer = new Printer();
         this.linguist = new Linguist();
         this.autoDetectLanguageType = false;
+        checkArgNotNull(rootNode, "rootNode");
+        this.rootNode = rootNode;
     }
 
-    public String toAsciiDoc(RootNode astRoot) {
-        checkArgNotNull(astRoot, "astRoot");
-        astRoot.accept(this);
-        return normalizeWhitelines(printer.getString());
+    public String toAsciiDoc() {
+    	cleanAst(rootNode);
+        rootNode.accept(this);
+        String result = normalizeWhitelines(printer.getString());
+        printer.clear();
+        return result;
     }
 
     public void visit(RootNode node) {
@@ -113,23 +120,24 @@ public class ToAsciiDocSerializer implements Visitor {
     }
 
     public void visit(ExpImageNode node) {
-        String text = printChildrenToString(node);
-        printImageTag(linkRenderer.render(node, text));
+    	String text = printChildrenToString(node);
+    	LinkRenderer.Rendering imageRenderer = linkRenderer.render(node, text);
+    	Node linkNode;
+    	if ((linkNode = findParentNode(node, rootNode)) instanceof ExpLinkNode) {
+    		printImageTagWithLink(imageRenderer, linkRenderer.render((ExpLinkNode) linkNode, null));
+    	}
+    	else {
+          printImageTag(linkRenderer.render(node, text));
+    	}
     }
 
     public void visit(ExpLinkNode node) {
         String text = printChildrenToString(node);
-        LinkRenderer.Rendering link = linkRenderer.render(node, text);
         if (text.startsWith("image:")) {
-            if (text.endsWith("[]")) {
-                printer.print(text.substring(0, text.length() - 1) + "link=" + link.href + "]");
-            }
-            else {
-                printer.print(text.substring(0, text.length() - 1) + ",link=" + link.href + "]");
-            }
+        	printer.print(text);
         }
         else {
-            printLink(link);
+        	printLink(linkRenderer.render(node, text));
         }
     }
 
@@ -184,7 +192,9 @@ public class ToAsciiDocSerializer implements Visitor {
     }
 
     public void visit(ParaNode node) {
-        printer.println().println();
+    	if (!isListItemText(node)) {
+    		printer.println().println();
+    	}
         visitChildren(node);
         printer.println().println();
     }
@@ -460,6 +470,25 @@ public class ToAsciiDocSerializer implements Visitor {
             child.accept(this);
         }
     }
+    
+    
+    /**
+     * Removes superfluous nodes from the tree.
+     */
+    protected void cleanAst(Node node) {
+    	List<Node> children = node.getChildren();
+    	for (int i = 0, len = children.size(); i < len; i++) {
+    		Node c = children.get(i);
+    		if (c instanceof RootNode) {
+    			children.set(i, c.getChildren().get(0));
+    		}
+    		else if (c.getClass().equals(SuperNode.class) && c.getChildren().size() == 1) {
+    			children.set(i, c.getChildren().get(0));
+    		}
+    		
+    		cleanAst(c);
+    	}
+    }
 
     protected void printNodeSurroundedBy(AbstractNode node, String token) {
         printer.print(token);
@@ -470,7 +499,19 @@ public class ToAsciiDocSerializer implements Visitor {
     protected void printImageTag(LinkRenderer.Rendering rendering) {
         printer.print("image:");
         printer.print(rendering.href);
-        printer.print('[').print(rendering.text).print(']');
+        printer.print('[');
+        printTextWithQuotesIfNeeded(printer, rendering.text);
+        printer.print(']');
+    }
+    
+    protected void printImageTagWithLink(LinkRenderer.Rendering image, LinkRenderer.Rendering link) {
+    	printer.print("image:").print(image.href).print('[');
+    	if (image.text != null && !image.text.isEmpty()) {
+    		printTextWithQuotesIfNeeded(printer, image.text);
+	    	printer.print(',');
+    	}
+
+    	printer.print("link=").print(link.href).print(']');
     }
 
     protected void printLink(LinkRenderer.Rendering rendering) {
@@ -482,7 +523,9 @@ public class ToAsciiDocSerializer implements Visitor {
         }
 
         printer.print(link);
-        printer.print('[').print(rendering.text).print("]");
+        printer.print('[');
+        printTextWithQuotesIfNeeded(printer, rendering.text);
+        printer.print(']');
     }
 
     protected String printChildrenToString(SuperNode node) {
@@ -512,6 +555,17 @@ public class ToAsciiDocSerializer implements Visitor {
     protected String normalizeWhitelines(String text) {
         // replace all double or more empty lines with single empty lines
         return text.replaceAll("(?m)^[ \t]*\r?\n{2,}", "\n").trim();
+    }
+    
+    protected void printTextWithQuotesIfNeeded(Printer p, String text) {
+    	if (text != null && !text.isEmpty()) {
+    		if (text.contains(",")) {
+    			p.print('"').print(text).print('"');
+    		}
+    		else {
+    			p.print(text);
+    		}
+    	}
     }
 
     protected void printWithAbbreviations(String string) {
@@ -565,5 +619,38 @@ public class ToAsciiDocSerializer implements Visitor {
         } else {
             printer.print(string);
         }
+    }
+ 
+    protected Node findParentNode(Node target, Node from) {
+    	if (target.equals(rootNode)) {
+    		return null;
+    	}
+    	
+    	Node candidate;
+    	
+    	for (Node c : from.getChildren()) {   		
+    		if (target.equals(c)) {
+    			return from;
+    		}
+    		else if ((candidate = findParentNode(target, c)) != null) {
+    			return candidate;
+    		}
+    	}
+    	
+    	return null;
+    }
+    
+    protected boolean isFirstChild(Node parent, Node child) {
+    	return child.equals(parent.getChildren().get(0));
+    }
+    
+    protected boolean isListItemText(Node node) {
+    	if (listLevel == 0) {
+    		return false;
+    	}
+    	else {
+    		Node parent = findParentNode(node, rootNode);
+    		return (parent instanceof ListItemNode && isFirstChild(parent, node));
+    	}
     }
 }

--- a/src/test/resources/com/laamella/markdown_to_asciidoc/links.feature
+++ b/src/test/resources/com/laamella/markdown_to_asciidoc/links.feature
@@ -16,6 +16,17 @@ Feature: Links
     This is http://example.com/[an example] inline link.
     """
 
+  Scenario: Render linked text with comma
+    Given the Markdown source
+    """
+    This is [a very, very cool](http://example.com/) inline link.
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    This is http://example.com/["a very, very cool"] inline link.
+    """
+
   Scenario: Render a reference style link with link definition
     Given the Markdown source
     """
@@ -68,6 +79,17 @@ Feature: Links
     image:images/icons/home.png[Alt text]
 
     image:images/icons/home.png?width=100[Alt text]
+    """
+
+  Scenario: Render an inline image with comma in alt text
+    Given the Markdown source
+    """
+    ![Alt,text](images/icons/home.png)
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    image:images/icons/home.png["Alt,text"]
     """
 
   Scenario: Render a hyperlinked inline image with alt text

--- a/src/test/resources/com/laamella/markdown_to_asciidoc/lists.feature
+++ b/src/test/resources/com/laamella/markdown_to_asciidoc/lists.feature
@@ -20,6 +20,21 @@ Feature: Lists
     * Item 3
     """
 
+  Scenario: Render an unordered list of paragraphs
+    Given the Markdown source
+    """
+    * Paragraph 1
+
+    * Paragraph 2
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    * Paragraph 1
+
+    * Paragraph 2
+    """
+
   Scenario: Render an unordered nested list
     Given the Markdown source
     """
@@ -89,6 +104,21 @@ Feature: Lists
     ..... Item 11211
     .. Item 12
     . Item 2
+    """
+
+  Scenario: Render an ordered list of paragraphs
+    Given the Markdown source
+    """
+    . Paragraph 1
+
+    . Paragraph 2
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    . Paragraph 1
+
+    . Paragraph 2
     """
 
   Scenario: Render an unordered list with a link


### PR DESCRIPTION
Another super hack, though hopefully the PR gives you the gist of the problem. List items that are separated by a blank line end up having a list marker on a separate line from the content...which breaks the list in AsciiDoc. I've done a quick hack here to not put a blank line before start of a paragraph when inside a list.

In general, I think the serializer should not put a blank link at the top of content, only at the bottom of content. That way, you can control better where endlines get placed. When they are added above and below, you lose a lot of control when using the recursive decent visitor strategy.
