### PR TITLE
revise description lists

### DIFF
--- a/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
+++ b/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
@@ -96,20 +96,22 @@ public class ToAsciiDocSerializer implements Visitor {
     }
 
     public void visit(DefinitionListNode node) {
-        printer.print("[glossary]").println();
-
+        printer.println();
         visitChildren(node);
+    }
+    
+    public void visit(DefinitionTermNode node) {
+        visitChildren(node);
+        printer.indent(2);
+        printer.print("::").println();
     }
 
     public void visit(DefinitionNode node) {
-        repeat(' ', 4);
         visitChildren(node);
+        if (printer.indent > 0) {
+            printer.indent(-2);
+        }
         printer.println();
-    }
-
-    public void visit(DefinitionTermNode node) {
-        visitChildren(node);
-        printer.print("::").println();
     }
 
     public void visit(ExpImageNode node) {
@@ -259,7 +261,7 @@ public class ToAsciiDocSerializer implements Visitor {
                 printer.println().print("'''");
                 break;
             case Linebreak:
-                printer.print("\n");
+                printer.println();
                 break;
             case Nbsp:
                 printer.print("{nbsp}");

--- a/src/test/resources/com/laamella/markdown_to_asciidoc/definition_lists.feature
+++ b/src/test/resources/com/laamella/markdown_to_asciidoc/definition_lists.feature
@@ -1,11 +1,11 @@
 # language: en
-@definitionlists
-Feature: Definition lists
-  In order to group content
+@descriptionlists
+Feature: Description lists
+  In order to describe terms
   As a writer
-  I want to be able to create definition lists
+  I want to be able to create description lists
 
-  Scenario: Render a definition list
+  Scenario: Render a description list
     Given the Markdown source
     """
     Apple
@@ -15,13 +15,12 @@ Feature: Definition lists
     When it is converted to AsciiDoc
     Then the result should match the AsciiDoc source
     """
-    [glossary]
     Apple::
-        Pomaceous fruit of plants of the genus Malus in
-    the family Rosaceae.
+      Pomaceous fruit of plants of the genus Malus in
+      the family Rosaceae.
     """
 
-  Scenario: Render a multiple definition lists
+  Scenario: Render a multiple description lists
     Given the Markdown source
     """
     Apple
@@ -34,13 +33,9 @@ Feature: Definition lists
     When it is converted to AsciiDoc
     Then the result should match the AsciiDoc source
     """
-    [glossary]
     Apple::
-        Pomaceous fruit of plants of the genus Malus in
-    the family Rosaceae.
+      Pomaceous fruit of plants of the genus Malus in
+      the family Rosaceae.
     Orange::
-        The fruit of an evergreen tree of the genus Citrus.
+      The fruit of an evergreen tree of the genus Citrus.
     """
-
-
-


### PR DESCRIPTION
- rename from definition lists to description lists
- drop glossary style
- correct indentation of term
