### PR TITLE
restore list marker after sublist

### DIFF
--- a/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
+++ b/src/main/java/com/laamella/markdown_to_asciidoc/ToAsciiDocSerializer.java
@@ -22,7 +22,7 @@ public class ToAsciiDocSerializer implements Visitor {
     protected int currentTableColumn;
     protected boolean inTableHeader;
 
-    protected char listToken;
+    protected char listMarker;
     protected int listLevel = 0;
     protected int blockQuoteLevel = 0;
 
@@ -90,10 +90,14 @@ public class ToAsciiDocSerializer implements Visitor {
     }
 
     public void visit(BulletListNode node) {
-        listToken = '*';
+        char prevListMarker = listMarker;
+        listMarker = '*';
+        
         listLevel = listLevel + 1;
         visitChildren(node);
         listLevel = listLevel - 1;
+        
+        listMarker = prevListMarker;
     }
 
     public void visit(CodeNode node) {
@@ -175,7 +179,7 @@ public class ToAsciiDocSerializer implements Visitor {
 
     public void visit(ListItemNode node) {
         printer.println();
-        repeat(listToken, listLevel);
+        repeat(listMarker, listLevel);
         printer.print(" ");
 
         visitChildren(node);
@@ -186,11 +190,14 @@ public class ToAsciiDocSerializer implements Visitor {
     }
 
     public void visit(OrderedListNode node) {
-        listToken = '.';
+        char prevListMarker = listMarker;
+        listMarker = '.';
 
         listLevel = listLevel + 1;
         visitChildren(node);
         listLevel = listLevel - 1;
+        
+        listMarker = prevListMarker;
     }
 
     public void visit(ParaNode node) {

--- a/src/test/resources/com/laamella/markdown_to_asciidoc/lists.feature
+++ b/src/test/resources/com/laamella/markdown_to_asciidoc/lists.feature
@@ -80,7 +80,6 @@ Feature: Lists
     .. Item 1.2
     """
 
-    @bug
   Scenario: Render a nested ordered list combined with unordered list
     Given the Markdown source
     """
@@ -104,6 +103,28 @@ Feature: Lists
     ..... Item 11211
     .. Item 12
     . Item 2
+    """
+
+  Scenario: Render an ordered list combined with a nested unordered list
+    Given the Markdown source
+    """
+    1. Item 1
+
+    2. Item 2
+
+        * Subitem of Item 2
+
+    3. Item 3
+    """
+    When it is converted to AsciiDoc
+    Then the result should match the AsciiDoc source
+    """
+    . Item 1
+
+    . Item 2
+
+    ** Subitem of Item 2
+    . Item 3
     """
 
   Scenario: Render an ordered list of paragraphs


### PR DESCRIPTION
This should fix the issue with mixed nested lists. The list marker (aka token) wasn't being restored after returning from the sublist.
